### PR TITLE
Update jackson databind

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.10.4</version>
+            <version>2.9.10.5</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
See https://github.com/vrischmann/bip39-java/network/alert/pom.xml/com.fasterxml.jackson.core:jackson-databind/open

dependabot proposed to use 2.10.0.pr1 but there's 2.9.10.5 which seems safer.